### PR TITLE
Switch installer to copy by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Then follow the instructions in the installer.
 
 Prerequisite: docker.
 
-1. Run `make` to build a docker image and start a container from it.
-2. Run `./install.sh` to test the installer.
-  - Run `./reset.sh` to undo the installation when you need to retest the installer.
-  - Optionally install any packages you may need to aid in testing (e.g. `sudo apt install vim` to test the vimconfig module).
+1. Run `make enter-test-env` to build the docker image and start an interactive container.
+2. Inside the container, run `./install.sh` to test the installer. This script invokes the installer with the `-e` (editable) flag so files are symlinked for faster iteration during development.
+   - Run `./reset.sh` to undo the installation when you need to retest the installer.
+   - Optionally install any packages you may need to aid in testing (e.g. `sudo apt install vim` to test the vimconfig module).
 3. Run `bash` to start a new bash shell and see the dotfiles come into effect.
 4. Test the final environment.

--- a/test/installer/install.sh
+++ b/test/installer/install.sh
@@ -2,4 +2,4 @@
 touch /tmp/SZCDF_G__DEBUG_MODE
 cp ~/.bashrc ~/.bashrc.old
 cp ~/.profile ~/.profile.old
-/szcdf-core/bin/szcdfi.sh
+/szcdf-core/bin/szcdfi.sh -e


### PR DESCRIPTION
Change installer default to copy files instead of symlinking, adding an `-e` flag for editable (symlink) mode.

The original behavior of symlinking files was suitable for development and testing, allowing quick iterations. However, for a production installation, it's preferable to have a self-contained copy of the files rather than relying on symlinks that point back to the source directory, which might not be present or stable in a production environment. This change makes the default behavior more robust for production use cases while retaining the development convenience via the new `-e` flag.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d274d8a-c427-46bd-a32f-d5a76b2aeb3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d274d8a-c427-46bd-a32f-d5a76b2aeb3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>