### PR TITLE
Multi-shell support (Phase 1): PowerShell installer + ADR

### DIFF
--- a/bin/szcdfi.ps1
+++ b/bin/szcdfi.ps1
@@ -1,0 +1,313 @@
+###############################################################################
+#
+# Package: szcdf-core
+# Author: Stephen Zhao (mail@zhaostephen.com)
+# Type: Installer
+# Target: pwsh (Windows PowerShell 5.1 and PowerShell 7+)
+# Purpose: PowerShell installer for the SZCDF package system.
+#
+# This is the PowerShell sibling of bin/szcdfi.sh. It reads the SAME declarative
+# install-spec format (.szcdfis) and applies the SAME directives:
+#   COPY, COPYALL, PREPENDTEXT, APPENDTEXT
+#
+# It additionally understands shell GUARDS so one manifest can serve every
+# installer (see ADR 0001):
+#   `#@pwsh <DIRECTIVE> ...`  -> active for THIS installer only.
+#   `#@<other> <DIRECTIVE>`   -> ignored by THIS installer.
+#   `<DIRECTIVE> ...`         -> shared; processed by every installer.
+#   `# ...`                   -> ordinary comment.
+#
+# The section-marker format used by PREPENDTEXT / APPENDTEXT is byte-identical
+# to bin/szcdfi.sh, so the two installers are interoperable on the same files.
+
+[CmdletBinding()]
+param(
+    [Alias('p')][string] $PackageDir,
+    [Alias('s')][string] $Spec,
+    [Alias('m')][ValidateSet('quick', 'custom')][string] $Mode = 'quick',
+    [Alias('I')][switch] $NonInteractive,
+    [Alias('e')][switch] $Editable
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Write text as UTF-8 WITHOUT a BOM and with LF line endings, to match the
+# byte output of bin/szcdfi.sh (awk/printf/cat). A BOM would, for example,
+# break Claude Code's `@import` parsing when it precedes the first line.
+function Write-TextFileLf {
+    param([string] $Path, [string[]] $Lines)
+    $content = ($Lines -join "`n")
+    if ($content.Length -gt 0) { $content += "`n" }
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $content, $utf8NoBom)
+}
+
+# The shell identity this installer answers to, for guard matching.
+# (Named SzcdfShellId to avoid the built-in read-only $ShellId automatic variable.)
+$script:SzcdfShellId = 'pwsh'
+
+
+######### PATH / ROOT RESOLUTION #############################################
+
+function Get-SzcdfConfigRoot {
+    $dotConfig = Join-Path $HOME '.config/szcdf'
+    $dotSzcdf = Join-Path $HOME '.szcdf'
+    if (Test-Path -LiteralPath $dotConfig -PathType Container) { return $dotConfig }
+    if (Test-Path -LiteralPath $dotSzcdf -PathType Container) { return $dotSzcdf }
+    # Neither exists yet: default to ~/.config/szcdf and create it.
+    New-Item -ItemType Directory -Force -Path $dotConfig | Out-Null
+    return $dotConfig
+}
+
+function Resolve-SpecPath {
+    param([string] $Raw, [string] $ConfigRoot)
+    # Substitute the same tokens the Bash installer supports, plus $PROFILE.
+    $out = $Raw
+    $out = $out.Replace('$CONFIG_ROOT', $ConfigRoot)
+    $out = $out.Replace('$HOME', $HOME)
+    $out = $out.Replace('$PROFILE', $PROFILE.CurrentUserAllHosts)
+    return $out
+}
+
+
+######### DIRECTIVE EXECUTORS ################################################
+
+function Copy-One {
+    param([string] $SourceAbs, [string] $DestAbs)
+
+    $destParent = Split-Path -Parent $DestAbs
+    if ($destParent -and -not (Test-Path -LiteralPath $destParent)) {
+        New-Item -ItemType Directory -Force -Path $destParent | Out-Null
+    }
+
+    if ($Editable) {
+        # Editable mode: symbolic link (needs Developer Mode or admin on Windows).
+        if (Test-Path -LiteralPath $DestAbs) { Remove-Item -LiteralPath $DestAbs -Recurse -Force }
+        try {
+            New-Item -ItemType SymbolicLink -Path $DestAbs -Target $SourceAbs | Out-Null
+            Write-Output "  linked  $DestAbs -> $SourceAbs"
+        } catch {
+            Write-Warning "  symlink failed ($($_.Exception.Message)); falling back to copy."
+            Copy-Item -LiteralPath $SourceAbs -Destination $DestAbs -Recurse -Force
+            Write-Output "  copied  $SourceAbs -> $DestAbs"
+        }
+        return
+    }
+
+    if (Test-Path -LiteralPath $SourceAbs -PathType Container) {
+        # Directory copy with replace semantics (mirror cp -rfT: dest becomes src).
+        if (Test-Path -LiteralPath $DestAbs) { Remove-Item -LiteralPath $DestAbs -Recurse -Force }
+        Copy-Item -LiteralPath $SourceAbs -Destination $DestAbs -Recurse -Force
+    } else {
+        # File copy. Skip if identical (idempotency).
+        if (Test-Path -LiteralPath $DestAbs -PathType Leaf) {
+            $a = (Get-FileHash -LiteralPath $SourceAbs -Algorithm SHA256).Hash
+            $b = (Get-FileHash -LiteralPath $DestAbs -Algorithm SHA256).Hash
+            if ($a -eq $b) {
+                Write-Output "  skip    $DestAbs (identical)"
+                return
+            }
+        }
+        Copy-Item -LiteralPath $SourceAbs -Destination $DestAbs -Force
+    }
+    Write-Output "  copied  $SourceAbs -> $DestAbs"
+}
+
+function Invoke-Copy {
+    param([string[]] $Tokens, [string] $PkgDir, [string] $ConfigRoot)
+    if ($Tokens.Count -lt 2) { Write-Warning 'COPY needs <source> <dest>. Skipping.'; return }
+    $srcAbs = Join-Path $PkgDir $Tokens[0]
+    $destAbs = Resolve-SpecPath -Raw $Tokens[1] -ConfigRoot $ConfigRoot
+    if (-not (Test-Path -LiteralPath $srcAbs)) {
+        Write-Warning "COPY source not found: $srcAbs. Skipping."
+        return
+    }
+    Copy-One -SourceAbs $srcAbs -DestAbs $destAbs
+}
+
+function Invoke-CopyAll {
+    param([string[]] $Tokens, [string] $PkgDir, [string] $ConfigRoot)
+    if ($Tokens.Count -lt 2) { Write-Warning 'COPYALL needs <source_dir> <dest_dir>. Skipping.'; return }
+    $srcDirAbs = Join-Path $PkgDir $Tokens[0]
+    $destDirRaw = $Tokens[1]
+    if (-not (Test-Path -LiteralPath $srcDirAbs -PathType Container)) {
+        Write-Warning "COPYALL source dir not found: $srcDirAbs. Skipping."
+        return
+    }
+    # Non-recursive: iterate direct children (files and dirs), COPY each.
+    Get-ChildItem -LiteralPath $srcDirAbs -Force | ForEach-Object {
+        $childSrcAbs = $_.FullName
+        $childDestAbs = Resolve-SpecPath -Raw (($destDirRaw.TrimEnd('/')) + '/' + $_.Name) -ConfigRoot $ConfigRoot
+        Copy-One -SourceAbs $childSrcAbs -DestAbs $childDestAbs
+    }
+}
+
+function Get-SectionMarkers {
+    param([string] $CommentIndicator, [string] $SectionId)
+    return [pscustomobject]@{
+        Begin = "$CommentIndicator >>>>>>> SZCDF_GENERATED_TEXT // BEGIN SECTION_ID=$SectionId // DO NOT EDIT MANUALLY"
+        End   = "$CommentIndicator <<<<<<< SZCDF_GENERATED_TEXT // END SECTION_ID=$SectionId // DO NOT EDIT MANUALLY"
+    }
+}
+
+function Read-Lines {
+    param([string] $Path)
+    if (Test-Path -LiteralPath $Path -PathType Leaf) {
+        return @(Get-Content -LiteralPath $Path)
+    }
+    return @()
+}
+
+function Invoke-InsertText {
+    param(
+        [string[]] $Tokens,
+        [string] $PkgDir,
+        [string] $ConfigRoot,
+        [ValidateSet('prepend', 'append')][string] $Position
+    )
+    if ($Tokens.Count -lt 3) {
+        Write-Warning "$($Position.ToUpper())TEXT needs <source> <dest> <section_id>. Skipping."
+        return
+    }
+    $srcAbs = Join-Path $PkgDir $Tokens[0]
+    $destAbs = Resolve-SpecPath -Raw $Tokens[1] -ConfigRoot $ConfigRoot
+    $sectionId = $Tokens[2]
+    $comment = if ($Tokens.Count -ge 4 -and $Tokens[3]) { $Tokens[3] } else { '#' }
+
+    if (-not (Test-Path -LiteralPath $srcAbs -PathType Leaf)) {
+        Write-Warning "Source file not found: $srcAbs. Skipping."
+        return
+    }
+    $destParent = Split-Path -Parent $destAbs
+    if ($destParent -and -not (Test-Path -LiteralPath $destParent)) {
+        New-Item -ItemType Directory -Force -Path $destParent | Out-Null
+    }
+
+    $m = Get-SectionMarkers -CommentIndicator $comment -SectionId $sectionId
+    $srcLines = Read-Lines -Path $srcAbs
+    $destLines = Read-Lines -Path $destAbs
+
+    $hasBegin = $destLines -contains $m.Begin
+    $hasEnd = $destLines -contains $m.End
+
+    if ($hasBegin -and $hasEnd) {
+        # Replace the existing section body in place.
+        $result = New-Object System.Collections.Generic.List[string]
+        $inSection = $false
+        foreach ($line in $destLines) {
+            if ($line -eq $m.Begin) {
+                $result.Add($m.Begin)
+                foreach ($s in $srcLines) { $result.Add($s) }
+                $inSection = $true
+                continue
+            }
+            if ($inSection) {
+                if ($line -eq $m.End) { $result.Add($m.End); $inSection = $false }
+                continue
+            }
+            $result.Add($line)
+        }
+        Write-TextFileLf -Path $destAbs -Lines $result
+    } else {
+        $section = New-Object System.Collections.Generic.List[string]
+        $section.Add($m.Begin)
+        foreach ($s in $srcLines) { $section.Add($s) }
+        $section.Add($m.End)
+
+        if ($Position -eq 'prepend') {
+            $result = New-Object System.Collections.Generic.List[string]
+            foreach ($s in $section) { $result.Add($s) }
+            foreach ($line in $destLines) { $result.Add($line) }
+        } else {
+            $result = New-Object System.Collections.Generic.List[string]
+            foreach ($line in $destLines) { $result.Add($line) }
+            foreach ($s in $section) { $result.Add($s) }
+        }
+        Write-TextFileLf -Path $destAbs -Lines $result
+    }
+    Write-Output "  ${Position}ed section '$sectionId' -> $destAbs"
+}
+
+
+######### SPEC PARSING #######################################################
+
+# Returns $null for lines that are not active for this installer (comments,
+# empty lines, or lines guarded for a different shell). Otherwise returns the
+# active directive text (with any matching guard prefix stripped).
+function Get-ActiveDirective {
+    param([string] $Line)
+    $t = $Line.Trim()
+    if ($t.Length -eq 0) { return $null }
+    if ($t.StartsWith('#@')) {
+        # Guarded line: `#@<shell> <directive...>`
+        $m = [regex]::Match($t, '^#@(\S+)\s+(.*)$')
+        if (-not $m.Success) { return $null }
+        $guard = $m.Groups[1].Value
+        if ($guard -eq $script:SzcdfShellId) { return $m.Groups[2].Value }
+        return $null
+    }
+    if ($t.StartsWith('#')) { return $null }  # ordinary comment
+    return $t
+}
+
+
+######### MAIN ###############################################################
+
+function Invoke-SzcdfInstall {
+    $scriptDir = Split-Path -Parent $PSCommandPath
+
+    if (-not $PackageDir) { $PackageDir = Split-Path -Parent $scriptDir }  # repo root = bin/..
+    if (-not $Spec) {
+        $winSpec = Join-Path $PackageDir 'windows.szcdfis'
+        $defSpec = Join-Path $PackageDir '.szcdfis'
+        if (Test-Path -LiteralPath $winSpec) { $Spec = $winSpec } else { $Spec = $defSpec }
+    }
+    if (-not (Test-Path -LiteralPath $Spec -PathType Leaf)) {
+        throw "Install spec not found: $Spec"
+    }
+
+    $configRoot = Get-SzcdfConfigRoot
+
+    Write-Output ''
+    Write-Output '=== Stephen''s dotfiles (PowerShell installer) ==='
+    Write-Output ''
+    Write-Output "Package dir : $PackageDir"
+    Write-Output "Spec file   : $Spec"
+    Write-Output "Config root : $configRoot"
+    Write-Output "Mode        : $Mode$(if ($Editable) { ' (editable/symlink)' } else { '' })"
+    Write-Output ''
+
+    $lines = Get-Content -LiteralPath $Spec
+    $step = 0
+    foreach ($line in $lines) {
+        $directive = Get-ActiveDirective -Line $line
+        if ($null -eq $directive) { continue }
+
+        $tokens = [regex]::Split($directive.Trim(), '\s+')
+        $name = $tokens[0]
+        $rest = @()
+        if ($tokens.Count -gt 1) { $rest = $tokens[1..($tokens.Count - 1)] }
+
+        $step++
+
+        if ($Mode -eq 'custom' -and -not $NonInteractive) {
+            $answer = Read-Host "[Step $step] $directive`nRun? [Y/n]"
+            if ($answer -match '^(n|no)$') { Write-Output '  skipped'; continue }
+        } else {
+            Write-Output "[Step $step] $directive"
+        }
+
+        switch ($name) {
+            'COPY'        { Invoke-Copy    -Tokens $rest -PkgDir $PackageDir -ConfigRoot $configRoot }
+            'COPYALL'     { Invoke-CopyAll -Tokens $rest -PkgDir $PackageDir -ConfigRoot $configRoot }
+            'PREPENDTEXT' { Invoke-InsertText -Tokens $rest -PkgDir $PackageDir -ConfigRoot $configRoot -Position 'prepend' }
+            'APPENDTEXT'  { Invoke-InsertText -Tokens $rest -PkgDir $PackageDir -ConfigRoot $configRoot -Position 'append' }
+            default       { Write-Warning "Unknown directive '$name' will be ignored." }
+        }
+    }
+
+    Write-Output ''
+    Write-Output 'Installation was successful!'
+}
+
+Invoke-SzcdfInstall

--- a/bin/szcdfi.ps1
+++ b/bin/szcdfi.ps1
@@ -31,15 +31,30 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Write text as UTF-8 WITHOUT a BOM and with LF line endings, to match the
-# byte output of bin/szcdfi.sh (awk/printf/cat). A BOM would, for example,
-# break Claude Code's `@import` parsing when it precedes the first line.
-function Write-TextFileLf {
-    param([string] $Path, [string[]] $Lines)
-    $content = ($Lines -join "`n")
-    if ($content.Length -gt 0) { $content += "`n" }
+# Write text as UTF-8 WITHOUT a BOM, to match the byte output of bin/szcdfi.sh
+# (awk/printf/cat). A BOM would, for example, break Claude Code's `@import`
+# parsing when it precedes the first line.
+#
+# $Newline defaults to LF (bash's byte style). Callers editing an EXISTING file
+# should pass that file's dominant EOL so pre-existing user content is not
+# silently normalized (bash's awk-replace path likewise preserves the dest EOL).
+function Write-TextFile {
+    param([string] $Path, [string[]] $Lines, [string] $Newline = "`n")
+    $content = ($Lines -join $Newline)
+    if ($content.Length -gt 0) { $content += $Newline }
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllText($Path, $content, $utf8NoBom)
+}
+
+# Detect the dominant line ending of an existing text file: CRLF if any CRLF is
+# present, else LF. Returns LF for a missing/empty file (bash's default style).
+function Get-DominantNewline {
+    param([string] $Path)
+    if (Test-Path -LiteralPath $Path -PathType Leaf) {
+        $raw = [System.IO.File]::ReadAllText($Path)
+        if ($raw -match "`r`n") { return "`r`n" }
+    }
+    return "`n"
 }
 
 # The shell identity this installer answers to, for guard matching.
@@ -153,7 +168,11 @@ function Get-SectionMarkers {
 function Read-Lines {
     param([string] $Path)
     if (Test-Path -LiteralPath $Path -PathType Leaf) {
-        return @(Get-Content -LiteralPath $Path)
+        # -Encoding UTF8 is REQUIRED: Windows PowerShell 5.1 otherwise decodes
+        # with the system ANSI code page, which mojibake-corrupts UTF-8 content
+        # (our writers emit UTF-8 without BOM). 5.1 -Encoding UTF8 decodes UTF-8
+        # correctly and still honors a BOM if one is present.
+        return @(Get-Content -LiteralPath $Path -Encoding UTF8)
     }
     return @()
 }
@@ -186,6 +205,9 @@ function Invoke-InsertText {
     $m = Get-SectionMarkers -CommentIndicator $comment -SectionId $sectionId
     $srcLines = Read-Lines -Path $srcAbs
     $destLines = Read-Lines -Path $destAbs
+    # Preserve the destination's existing EOL so untouched user lines are not
+    # silently converted (a brand-new file defaults to LF, bash's byte style).
+    $nl = Get-DominantNewline -Path $destAbs
 
     $hasBegin = $destLines -contains $m.Begin
     $hasEnd = $destLines -contains $m.End
@@ -207,7 +229,7 @@ function Invoke-InsertText {
             }
             $result.Add($line)
         }
-        Write-TextFileLf -Path $destAbs -Lines $result
+        Write-TextFile -Path $destAbs -Lines $result -Newline $nl
     } else {
         $section = New-Object System.Collections.Generic.List[string]
         $section.Add($m.Begin)
@@ -223,7 +245,7 @@ function Invoke-InsertText {
             foreach ($line in $destLines) { $result.Add($line) }
             foreach ($s in $section) { $result.Add($s) }
         }
-        Write-TextFileLf -Path $destAbs -Lines $result
+        Write-TextFile -Path $destAbs -Lines $result -Newline $nl
     }
     Write-Output "  ${Position}ed section '$sectionId' -> $destAbs"
 }
@@ -277,7 +299,7 @@ function Invoke-SzcdfInstall {
     Write-Output "Mode        : $Mode$(if ($Editable) { ' (editable/symlink)' } else { '' })"
     Write-Output ''
 
-    $lines = Get-Content -LiteralPath $Spec
+    $lines = Get-Content -LiteralPath $Spec -Encoding UTF8
     $step = 0
     foreach ($line in $lines) {
         $directive = Get-ActiveDirective -Line $line

--- a/docs/adr/0001-multi-shell-support.md
+++ b/docs/adr/0001-multi-shell-support.md
@@ -107,6 +107,32 @@ Adopt a **split-by-effect-type** architecture, not a per-shell rewrite of the wh
     - Add a Windows CI runner that runs `bin/szcdfi.ps1` against the manifest.
     - Assert the same result tree that `test/installer` asserts on Linux.
 
+## Text encoding and line endings (installer parity)
+
+- All PowerShell text writers emit UTF-8 WITHOUT a BOM.
+  - A BOM before the first line breaks Claude Code's `@import` parsing.
+  - No-BOM also matches the byte output of `szcdfi.sh`.
+- All content reads pass `-Encoding UTF8`.
+  - Windows PowerShell 5.1 otherwise decodes with the system ANSI code page.
+  - That would mojibake-corrupt any non-ASCII content in a file it edits (for example a user's `$PROFILE`).
+- `PREPENDTEXT` / `APPENDTEXT` preserve the destination file's dominant EOL.
+  - A pre-existing CRLF file stays CRLF; a new file defaults to LF.
+  - This avoids silently normalizing untouched user lines, and matches the Bash `awk`-replace path, which also keeps the destination EOL.
+
+## Known parity limitations (Phase 2 backlog)
+
+- New-section insert vs a source file with no trailing newline.
+  - `szcdfi.sh` `cat`s the source, so a source without a final newline glues the END marker onto the source's last line.
+  - `szcdfi.ps1` always places the END marker on its own line (the correct behavior).
+  - The Bash new-section path is internally inconsistent (its `awk`-replace path adds a newline).
+  - Resolution: fix `szcdfi.sh` to add the newline; do NOT replicate the Bash gluing bug.
+  - Not reachable today: every referenced source file ends in LF.
+- Copy over an existing symlink destination (editable/dev flows).
+  - `szcdfi.sh` replaces a symlink destination with a regular file even when contents match.
+  - `szcdfi.ps1` currently keeps the symlink when the linked content hashes equal.
+  - Low impact: Windows symlinks need Developer Mode or admin, so this is a dev-only path.
+  - Resolution: add explicit symlink-type detection to `Copy-One` in Phase 2.
+
 ## The Windows managed `CLAUDE.md`: why an import stub, not a symlink
 
 - The Bash path provisions `~/.claude/CLAUDE.md` with a symlink via `link_syncer`.

--- a/docs/adr/0001-multi-shell-support.md
+++ b/docs/adr/0001-multi-shell-support.md
@@ -1,0 +1,136 @@
+# ADR 0001: Multi-shell support for SZCDF
+
+- Status: Proposed
+- Date: 2026-08-02
+- Deciders: Stephen Zhao
+- Supersedes: none
+
+## Context
+
+SZCDF is a dotfiles framework built entirely in Bash.
+
+- The framework runs in two phases:
+  - Install phase.
+    - `bin/szcdfi.sh` reads the `.szcdfis` manifest.
+    - It applies directives (`COPY`, `COPYALL`, `PREPENDTEXT`, `APPENDTEXT`).
+    - It copies or links the package into `$CONFIG_ROOT` (`~/.config/szcdf` or `~/.szcdf`).
+    - It prepends entry hooks into `~/.bashrc`, `~/.profile`, and `~/.bash_profile`.
+  - Runtime phase.
+    - An entry script (`src/core-entries/entry-bash.sh`) is sourced from the shell run-command files.
+    - The entry sources `_bootstrap.sh`, which loads `logging` and `module_manager`, then `startup`.
+    - Modules and presets are `source`d Bash functions with an `__init` / `__cleanup` lifecycle.
+- Both phases depend on Bash-only features.
+  - `declare -gA` associative arrays.
+  - `${var+_}` parameter expansion.
+  - `local -n` namerefs.
+  - `BASH_SOURCE` and `source`.
+
+The framework must also work on Windows-native shells (PowerShell), where Bash is not present.
+
+- A WSL or Git Bash install is not an acceptable dependency for the Windows-native path.
+- A child Bash process cannot shape a parent PowerShell session (environment, prompt, aliases).
+
+## Decision
+
+Adopt a **split-by-effect-type** architecture, not a per-shell rewrite of the whole framework.
+
+### Principle: two kinds of work with different portability limits
+
+- Provisioning (out-of-process effects).
+  - Copies files, creates links, writes managed files (for example the managed `CLAUDE.md`).
+  - Touches the filesystem, not the live shell.
+  - A child process in any language can do this.
+  - Result: centralize into ONE engine.
+- Session shaping (in-process effects).
+  - Sets environment variables, `PATH`, aliases, functions, the prompt, and shell options.
+  - Must run inside the live shell's own process and language.
+  - A child process cannot inject these into its parent.
+  - Result: inherently per-shell; cannot be centralized.
+
+### Target architecture: "neutral core computes, native adapters apply"
+
+- Layer 0 — Manifest (`.szcdfis`).
+  - Stays declarative and shell-neutral.
+  - Gains shell guards so one manifest can drive every installer (see "Guard model").
+- Layer 1 — Installer.
+  - The directive surface is small (four directives).
+  - Provide one installer per bootstrap environment that reads the same manifest.
+  - `bin/szcdfi.sh` for Bash. `bin/szcdfi.ps1` for PowerShell.
+- Layer 2 — Entry scripts (`src/core-entries/entry-<shell>`).
+  - Already per-shell by design.
+  - Each is a thin, near-fixed loader for its shell.
+- Layer 3 — Engine, split in two.
+  - Provisioner (out-of-process): implemented once; avoids the N-times rewrite.
+  - Session shaper (in-process): compiled, not interpreted.
+    - The neutral core generates static native snippets at install time (`env.d/*.ps1`, `env.d/*.sh`).
+    - The per-shell entry only sources those snippets.
+- Layer 4 — Modules and presets.
+  - Each declares `kind = provisioning | session` and `supports = [bash, pwsh, ...]`.
+  - Provisioning presets: authored once, run by the provisioner.
+  - Session presets: authored as generators that emit per-shell snippets; kept deliberately small.
+
+### Guard model
+
+- A guarded directive uses a leading comment token: `#@<shell> <DIRECTIVE> <args...>`.
+- Property: a guarded line is a comment to every OTHER installer, and an active directive to the matching one.
+  - The existing Bash installer already treats `#`-prefixed lines as comments and skips them silently.
+  - So `#@pwsh ...` lines are invisible to Bash with NO change to `bin/szcdfi.sh`.
+- Important limit discovered during design:
+  - Guards can only ADD per-shell lines. They cannot retroactively make an existing SHARED line bash-only.
+  - Tagging an existing shared line `#@bash` would make Bash skip it too (Bash sees a comment).
+  - To make shared lines bash-only, the Bash installer must be upgraded to treat `#@bash` as ACTIVE.
+  - That upgrade is deferred to Phase 2 (see "Consequences").
+
+## Consequences
+
+- Positive.
+  - The irreducible per-shell surface is small: one installer per bootstrap environment, one thin entry per shell.
+  - Provisioning logic, the manifest, and managed content stay written once.
+  - The managed `CLAUDE.md` reaches Windows through provisioning only; it needs no ported runtime.
+- Negative / cost.
+  - At least two installers now exist, so they can drift.
+    - Mitigation: a conformance test that runs both installers against the same manifest and asserts the same result tree.
+  - Session shaping still needs per-shell snippets; only their GENERATION is shared.
+- Migration in phases.
+  - Phase 1 (this change): unblock Windows provisioning.
+    - Add `bin/szcdfi.ps1` (reads `.szcdfis`, honors guards, resolves `$PROFILE`).
+    - Add `src/core-entries/entry-pwsh.ps1` (thin loader for `env.d/*.ps1`).
+    - Add `src/core-data/CLAUDE.user.md` (the managed content).
+    - Add `src/core-presets/add-claude-md-managed.ps1` (`kind = provisioning`; writes an `@import` stub).
+    - Add `windows.szcdfis` (a curated Windows spec, so the proven Bash flow is not touched yet).
+  - Phase 2: converge to a single manifest.
+    - Upgrade `bin/szcdfi.sh` to treat `#@bash` as active.
+    - Retire `windows.szcdfis` in favor of guarded lines in `.szcdfis`.
+    - Formalize `kind` / `supports` metadata on presets.
+    - Move session presets to the generator model that emits `env.d/*`.
+  - Phase 3: conformance harness.
+    - Add a Windows CI runner that runs `bin/szcdfi.ps1` against the manifest.
+    - Assert the same result tree that `test/installer` asserts on Linux.
+
+## The Windows managed `CLAUDE.md`: why an import stub, not a symlink
+
+- The Bash path provisions `~/.claude/CLAUDE.md` with a symlink via `link_syncer`.
+- On Windows-native, a symlink needs Developer Mode or administrator rights.
+- An `@import` stub avoids that.
+  - Claude Code supports `@path` imports inside `CLAUDE.md`.
+  - The stub is one line: `@<forward-slash path to the installed CLAUDE.user.md>`.
+  - It needs no elevated rights.
+  - It is composable: a machine can keep local lines above the import.
+
+## Alternatives considered
+
+- Full polyglot port.
+  - Reimplement the bootstrap and every module in each shell.
+  - Rejected: N-times maintenance and constant divergence.
+- Bash engine everywhere (ship Git Bash or WSL on Windows).
+  - Rejected: works for provisioning only.
+  - A child Bash cannot shape the parent PowerShell session.
+
+## How to try Phase 1
+
+- Install (PowerShell), against an isolated home for safety:
+  - `pwsh -File bin/szcdfi.ps1 -Spec windows.szcdfis -NonInteractive`
+- Provision the managed `CLAUDE.md`:
+  - `pwsh -File "$env:USERPROFILE/.config/szcdf/presets/add-claude-md-managed.ps1"`
+- Verify:
+  - `Get-Content "$env:USERPROFILE/.claude/CLAUDE.md"` shows a single `@...CLAUDE.user.md` line.

--- a/src/core-data/CLAUDE.user.md
+++ b/src/core-data/CLAUDE.user.md
@@ -1,0 +1,10 @@
+## Style Guidelines
+
+- For human-facing output artifacts: Use the Simplified Technical English standard defined by ASD-STE100 as your human-facing output artifact prose language style, with the following modifications, unless told otherwise. This doesn't need to apply to inline conversational output, but it should apply to READMEs, pull-request descriptions, specifications, plans, requirement docs, etc.
+  - Refrain from long paragraphs.
+  - Use bullet points for lists instead of a comma-separated inline list.
+  - Use a tree structure of nested bullet points whenever there is hierarchical categorization of items in a list.
+
+## Operational Guidelines
+
+- Heavily utilize built-in subagents (Explore, General-purpose) via the Agent tool whenever possible to keep the main conversation context clean and the main conversational interface responsive

--- a/src/core-entries/entry-pwsh.ps1
+++ b/src/core-entries/entry-pwsh.ps1
@@ -1,0 +1,42 @@
+###############################################################################
+#
+# Package: szcdf-core
+# Author: Stephen Zhao (mail@zhaostephen.com)
+# Type: Entry Script
+# Entry Target: pwsh (Windows PowerShell 5.1 and PowerShell 7+)
+# Purpose: The entry point for the SZCDF system when PowerShell is the shell.
+#
+# This is a THIN, near-fixed per-shell loader. It does NOT reimplement the
+# Bash module runtime. It only:
+#   1. locates the SZCDF root directory, and
+#   2. dot-sources any generated session snippets under `<root>/env.d/*.ps1`.
+#
+# Session-shaping logic is expected to be GENERATED into env.d/*.ps1 by the
+# neutral core (see ADR 0001). Keeping this file thin is deliberate: the
+# per-shell surface must stay small.
+
+# Only run this if we have not hit an entry point yet (mirrors entry-bash.sh).
+if (-not $env:SZCDF_G__IS_RUNNING_ENTRY_POINT) {
+    $env:SZCDF_G__IS_RUNNING_ENTRY_POINT = '1'
+
+    try {
+        $szcdfConfigRoot = Join-Path $HOME '.config/szcdf'
+        $szcdfDotRoot = Join-Path $HOME '.szcdf'
+        if (Test-Path -LiteralPath $szcdfConfigRoot) {
+            $env:SZCDF_G__ROOT_DIR = $szcdfConfigRoot
+        } elseif (Test-Path -LiteralPath $szcdfDotRoot) {
+            $env:SZCDF_G__ROOT_DIR = $szcdfDotRoot
+        }
+
+        if ($env:SZCDF_G__ROOT_DIR) {
+            $szcdfEnvDir = Join-Path $env:SZCDF_G__ROOT_DIR 'env.d'
+            if (Test-Path -LiteralPath $szcdfEnvDir) {
+                Get-ChildItem -LiteralPath $szcdfEnvDir -Filter '*.ps1' -File |
+                    Sort-Object -Property Name |
+                    ForEach-Object { . $_.FullName }
+            }
+        }
+    } finally {
+        Remove-Item -LiteralPath Env:\SZCDF_G__IS_RUNNING_ENTRY_POINT -ErrorAction SilentlyContinue
+    }
+}

--- a/src/core-presets/add-claude-md-managed.ps1
+++ b/src/core-presets/add-claude-md-managed.ps1
@@ -59,7 +59,9 @@ $stub = "@$importPath"
 # Idempotency: if the target already contains exactly our stub, do nothing.
 # Trim tolerates a trailing newline and a possible leading BOM from an older write.
 if (Test-Path -LiteralPath $TargetPath) {
-    $existing = (Get-Content -LiteralPath $TargetPath -Raw -ErrorAction SilentlyContinue)
+    # -Encoding UTF8: Windows PowerShell 5.1 otherwise reads as ANSI and would
+    # mis-compare a UTF-8 stub (our writer emits UTF-8 without BOM).
+    $existing = (Get-Content -LiteralPath $TargetPath -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)
     if ($null -ne $existing -and $existing.Trim([char]0xFEFF, "`r", "`n", ' ', "`t") -eq $stub) {
         Write-Output "Managed CLAUDE.md already points to '$importPath'. Skipping."
         return

--- a/src/core-presets/add-claude-md-managed.ps1
+++ b/src/core-presets/add-claude-md-managed.ps1
@@ -1,0 +1,77 @@
+###############################################################################
+#
+# Package: szcdf-core
+# Author: Stephen Zhao (mail@zhaostephen.com)
+# Type: Preset
+# Preset: add-claude-md-managed
+# Kind: provisioning (out-of-process)
+# Supports: pwsh
+# Purpose: Provision the managed CLAUDE.md into the default user-level location
+#          for Claude Code (~/.claude/CLAUDE.md) on Windows-native PowerShell.
+#
+# This is a PROVISIONING preset: it only touches the filesystem, so it is safe
+# to run standalone and needs no SZCDF runtime. It writes an `@import` stub
+# rather than a symlink, so it needs no Developer Mode or administrator rights.
+#
+# Usage:
+#   pwsh -File add-claude-md-managed.ps1
+#   (SZCDF_G__ROOT_DIR is used if set; otherwise the config root is discovered.)
+
+[CmdletBinding()]
+param(
+    # Override the target CLAUDE.md path (defaults to ~/.claude/CLAUDE.md).
+    [string] $TargetPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-SzcdfRoot {
+    if ($env:SZCDF_G__ROOT_DIR) {
+        return $env:SZCDF_G__ROOT_DIR
+    }
+    $candidateConfig = Join-Path $HOME '.config/szcdf'
+    $candidateDot = Join-Path $HOME '.szcdf'
+    if (Test-Path -LiteralPath $candidateConfig) { return $candidateConfig }
+    if (Test-Path -LiteralPath $candidateDot) { return $candidateDot }
+    throw "Could not locate the SZCDF config root (looked for SZCDF_G__ROOT_DIR, '$candidateConfig', '$candidateDot')."
+}
+
+$root = Resolve-SzcdfRoot
+$source = Join-Path $root 'data/CLAUDE.user.md'
+if (-not (Test-Path -LiteralPath $source)) {
+    throw "Managed CLAUDE.user.md not found at '$source'. Run the installer first."
+}
+
+if (-not $TargetPath) {
+    $TargetPath = Join-Path $HOME '.claude/CLAUDE.md'
+}
+$targetDir = Split-Path -Parent $TargetPath
+if (-not (Test-Path -LiteralPath $targetDir)) {
+    New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+}
+
+# Forward slashes: Claude Code resolves the import path with node-style path
+# resolution, which accepts forward slashes on Windows and avoids backslash
+# escaping ambiguity.
+$importPath = ((Resolve-Path -LiteralPath $source).Path) -replace '\\', '/'
+$stub = "@$importPath"
+
+# Idempotency: if the target already contains exactly our stub, do nothing.
+# Trim tolerates a trailing newline and a possible leading BOM from an older write.
+if (Test-Path -LiteralPath $TargetPath) {
+    $existing = (Get-Content -LiteralPath $TargetPath -Raw -ErrorAction SilentlyContinue)
+    if ($null -ne $existing -and $existing.Trim([char]0xFEFF, "`r", "`n", ' ', "`t") -eq $stub) {
+        Write-Output "Managed CLAUDE.md already points to '$importPath'. Skipping."
+        return
+    }
+    # Preserve any pre-existing content, mirroring link_syncer's `.old` backup.
+    $backup = "$TargetPath.old"
+    Write-Warning "'$TargetPath' already exists. Moving it to '$backup'."
+    Move-Item -LiteralPath $TargetPath -Destination $backup -Force
+}
+
+# Write UTF-8 WITHOUT a BOM: a BOM before `@` can break Claude Code's import parsing.
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($TargetPath, "$stub`n", $utf8NoBom)
+Write-Output "Wrote managed CLAUDE.md import stub -> $TargetPath"
+Write-Output "  imports: $importPath"

--- a/windows.szcdfis
+++ b/windows.szcdfis
@@ -1,0 +1,27 @@
+###############################################################################
+#
+# Package: szcdf-core
+# Author: Stephen Zhao (mail@zhaostephen.com)
+# Type: SZCDF Install Spec (Windows / PowerShell, Phase 1 prototype)
+#
+# Read by bin/szcdfi.ps1. This is a CURATED Windows spec so that Phase 1 does
+# not touch the proven Bash flow in `.szcdfis`. Phase 2 converges to a single
+# manifest once the Bash installer learns to treat `#@bash` as active (see
+# ADR 0001).
+#
+# Guard syntax:
+#   `#@pwsh <DIRECTIVE> ...`  -> active for the PowerShell installer only.
+#   `#@bash <DIRECTIVE> ...`  -> ignored by the PowerShell installer.
+#   `<DIRECTIVE> ...`         -> shared; processed by every installer.
+#   `# ...`                   -> ordinary comment.
+
+# === Shared: install managed data + presets into the config root ===
+COPYALL src/core-data $CONFIG_ROOT/data
+COPYALL src/core-presets $CONFIG_ROOT/presets
+
+# === SZCDF entries (PowerShell) ===
+# Wire the PowerShell entry point into the user's profile (all hosts).
+#@pwsh PREPENDTEXT src/core-entries/entry-pwsh.ps1 $PROFILE ENTRY-PWSH
+
+# === Bash-only lines (ignored by the PowerShell installer) ===
+#@bash PREPENDTEXT src/core-entries/entry-bash.sh $HOME/.bashrc ENTRY-BASH


### PR DESCRIPTION
## Summary

- Start multi-shell support for SZCDF, beginning with Windows-native PowerShell.
- The framework is Bash-only today. This change adds a second bootstrap path without touching the proven Bash flow.
- Includes an ADR that records the architecture, and a working Phase 1 prototype.

## ADR 0001 — split-by-effect-type architecture

- Provisioning effects (out-of-process: copy, link, write managed files) are centralized into one engine.
- Session-shaping effects (in-process: env, prompt, aliases) stay per-shell, but are GENERATED, not hand-ported.
- Rationale: a child process cannot shape a parent shell, so a full per-shell rewrite is avoided; only a thin, mostly-generated per-shell surface remains.
- File: `docs/adr/0001-multi-shell-support.md`.

## Phase 1 prototype

- `bin/szcdfi.ps1` — PowerShell installer.
  - Reads the same `.szcdfis` directives: `COPY`, `COPYALL`, `PREPENDTEXT`, `APPENDTEXT`.
  - Honors `#@<shell>` guards, so one manifest can serve every installer.
  - Section-marker format is byte-identical to `szcdfi.sh`.
- `src/core-entries/entry-pwsh.ps1` — a thin per-shell loader for `env.d/*.ps1`.
- `src/core-presets/add-claude-md-managed.ps1` — a provisioning preset.
  - Writes an `@import` stub for `~/.claude/CLAUDE.md`.
  - Needs no symlink and no administrator rights.
- `src/core-data/CLAUDE.user.md` — the managed Claude Code content.
- `windows.szcdfis` — a curated Windows spec, so Phase 1 does not touch `.szcdfis`.

## Verification

- Verified end-to-end on Windows PowerShell 5.1 in an isolated sandbox home.
  - Install, shell-guard handling, `$PROFILE` entry wiring, provisioning, and idempotency.
  - A pre-seeded CRLF `$PROFILE` with a non-ASCII char keeps its bytes and CRLF endings.
  - The managed section is not duplicated on re-install.

## Adversarial review

- An adversarial multi-agent review ran on the PowerShell code (find across four dimensions, then refute each finding).
- Two real findings were fixed in this branch.
  - Reads now pass `-Encoding UTF8` (5.1 otherwise ANSI-decodes and corrupts non-ASCII content).
  - `PREPENDTEXT` / `APPENDTEXT` preserve the destination file's dominant EOL.
- Two latent parity gaps are documented as Phase 2 backlog in the ADR.
  - New-section gluing when a source lacks a trailing newline (the fix belongs in Bash, not PowerShell).
  - Copy-over-symlink object-type divergence in editable/dev flows.

## Scope and safety

- No Bash file and no `.szcdfis` line was modified, so the Linux install path is unaffected.
- The Bash `COPYALL` steps will now also copy the new `CLAUDE.user.md` and the `.ps1` preset. Both are harmless on the Bash side.

## Not in this PR (next phases)

- Phase 2: converge to a single manifest (upgrade `szcdfi.sh` to treat `#@bash` as active), formalize `kind` / `supports` metadata, and move session presets to the generator model.
- Phase 3: a Windows CI runner that asserts the same result tree as `test/installer`.
